### PR TITLE
Add plot_data_2d method

### DIFF
--- a/smelli/_version.py
+++ b/smelli/_version.py
@@ -1,2 +1,2 @@
-__version__ = '2.0.0'
-__flavio__version__ = '2.0.0'
+__version__ = '2.1.0'
+__flavio__version__ = '2.1.0'

--- a/smelli/classes.py
+++ b/smelli/classes.py
@@ -13,6 +13,7 @@ from .ckm import get_ckm_schemes
 from multipledispatch import dispatch
 from copy import copy
 import os
+from functools import partial
 
 
 # by default, smelli uses leading log accuracy for SMEFT running!
@@ -441,6 +442,81 @@ class GlobalLikelihood(object):
             nobs_dict[name] = clh.get_number_observations()
         nobs_dict['global'] = sum([v for k, v in nobs_dict.items() if 'custom_' not in k])
         return nobs_dict
+
+    def plot_data_2d(self,
+                     wc_fct,
+                     x_min, x_max, y_min, y_max,
+                     scale,
+                     steps=20,
+                     threads=1):
+        """Compute the likelihood on a grid of two non-zero Wilson coefficients.
+
+        This method is meant for producing contour plots with `flavio.plots`
+        and `matplotlib` in the plane of two Wilson coefficients.
+
+        Parameters:
+
+        - `coeff_x`: Wilson coefficient on x axis (string)
+        - `coeff_y`: Wilson coefficient on y axis (string)
+        - `x_min`: minimum value of Wilson coefficient on x axis
+        - `x_max`: maximum value of Wilson coefficient on x axis
+        - `y_min`: minimum value of Wilson coefficient on y axis
+        - `y_max`: maximum value of Wilson coefficient on y axis
+        - `scale`: renormalization scale in GeV
+        - `steps`: number of steps in each direction. The computing time scales
+                   with the square of this number.
+        - `threads`: number of threads for parallel computation (default: 1)
+
+        Returns:
+
+        A dictionary of the  form
+        `{'likelihood_A': dat_A, 'likelihood_B': dat_B, ...}`
+        where `'likelihood_A'` etc. are the names of the sub- and custom
+        likelihoods (as return by `GlobalLikelihoodPoint.log_likelihood_dict`)
+        and `dat_A` etc. are dictionaries with the keys `x`, `y`, `z`, that
+        can be directly fed to the `flavio.plots.contour` plot function.
+        """
+        _x = np.linspace(x_min, x_max, steps)
+        _y = np.linspace(y_min, y_max, steps)
+        x, y = np.meshgrid(_x, _y)
+        xy = np.array([x, y]).reshape(2, steps**2).T
+        xy_enumerated = list(enumerate(xy))
+        ll = partial(_log_likelihood_2d, gl=self, wc_fct=wc_fct, scale=scale)
+        from multiprocessing import Pool
+        # print(ll(xy_enumerated[0]))
+        # print(ll(xy_enumerated[-1]))
+        if threads > 1:
+            pool =  Pool(threads)
+            ll_dict_list_enumerated = pool.map(ll, xy_enumerated)
+            pool.close()
+            pool.join()
+        else:
+            ll_dict_list_enumerated = map(ll, xy_enumerated)
+        ll_enumerated_dict = dict(list(ll_dict_list_enumerated))
+        order_keys = sorted(ll_enumerated_dict.keys())
+        ll_dict_list = [ll_enumerated_dict[k] for k in order_keys]
+        plotdata = {}
+        keys = ll_dict_list[0].keys()  # look at first dict to fix keys
+        for k in keys:
+            z = -2 * np.array([ll_dict[k] for ll_dict in ll_dict_list]).reshape((steps, steps))
+            plotdata[k] = {'x': x, 'y': y, 'z': z}
+        for k in plotdata:
+            z = np.array(plotdata[k]['z'])
+            plotdata[k]['z'] = z - np.min(z)
+        return plotdata
+
+
+def _log_likelihood_2d(xy_enumerated, gl, wc_fct, scale):
+    """Compute the likelihood on a 2D grid of 2 Wilson coefficients.
+
+    This function is necessary because multiprocessing requires a picklable
+    (i.e. top-level) object for parallel computation.
+    """
+    number, xy = xy_enumerated
+    x, y = xy
+    pp = gl.parameter_point(wc_fct(x, y), scale)
+    ll_dict = pp.log_likelihood_dict()
+    return (number, ll_dict)
 
 
 class CustomLikelihood(object):


### PR DESCRIPTION
This adds a method `plot_data_2d` to `GlobalLikelihoodPoint`. This is based on code developed by @peterstangl and me for https://arxiv.org/abs/1903.10434. It allows to compute the likelihood on a 2D grid as needed for plotting with `flavio.plots`, but doing this not only for the global likelihood but also for all sub-likelihoods and custom likelihoods *without* recomputing any observables. This is a huge time saver for making pretty band plots.