### PR TITLE
remove low-q2 bin in Lambdab decays

### DIFF
--- a/smelli/data/yaml/observables_lambdablambdall_br.yaml
+++ b/smelli/data/yaml/observables_lambdablambdall_br.yaml
@@ -1,6 +1,3 @@
 - name: <dBR/dq2>(Lambdab->Lambdamumu)
-  q2min: 1.1
-  q2max: 6
-- name: <dBR/dq2>(Lambdab->Lambdamumu)
   q2min: 15
   q2max: 20


### PR DESCRIPTION
@DavidMStraub, I think the 1.1-6 GeV^2 bin should be removed for the Lambdab decay, right?