### PR TITLE
avoid yaml import bug

### DIFF
--- a/smelli/data/yaml/fast_likelihood_quarks_fixckm.yaml
+++ b/smelli/data/yaml/fast_likelihood_quarks_fixckm.yaml
@@ -24,8 +24,7 @@ observables: !include_merge_list
   - observables_beta.yaml
   - observables_udlnu.yaml
   # CKM input observables
-  - BR(B+->taunu)
-  - DeltaM_d
+  - observables_ckm_input.yaml
 exclude_measurements:
   - LHCb B->K*mumu 2015 S 1.1-2.5
   - LHCb B->K*mumu 2015 S 2.5-4

--- a/smelli/data/yaml/observables_ckm_input.yaml
+++ b/smelli/data/yaml/observables_ckm_input.yaml
@@ -1,0 +1,2 @@
+- BR(B+->taunu)
+- DeltaM_d


### PR DESCRIPTION
This avoids a bug in the current `flavio` version described in issue https://github.com/flav-io/flavio/issues/128. It allows `smelli` to work properly until the bug is fixed in `flavio`.