### PR TITLE
Add mu-e conversion to the LFV likelihood

### DIFF
--- a/smelli/data/yaml/likelihood_lfv.yaml
+++ b/smelli/data/yaml/likelihood_lfv.yaml
@@ -3,7 +3,7 @@ observables: !include_merge_list
   - observables_blfv.yaml
   # s->dll'
   - observables_klfv.yaml
-  # LFV
+  # l->l'X and mu-e conversion on nuclei
   - observables_lfv.yaml
 include_measurements: !include_merge_list
   - measurements_lfv.yaml

--- a/smelli/data/yaml/measurements_lfv.yaml
+++ b/smelli/data/yaml/measurements_lfv.yaml
@@ -11,3 +11,5 @@
 - PDG 2017 mu LFV
 - PDG 2017 tau LFV
 - PDG 2018 Kll
+- Sindrum II Ti 1993
+- Sindrum II Au 2006

--- a/smelli/data/yaml/observables_lfv.yaml
+++ b/smelli/data/yaml/observables_lfv.yaml
@@ -12,3 +12,5 @@
 - BR(tau->rhomu)
 - BR(tau->phie)
 - BR(tau->phimu)
+- CR(mu->e, Ti)
+- CR(mu->e, Au)


### PR DESCRIPTION
Based on #38, this PR adds the mu->e conversion on nuclei to the LFV likelihood. In particular, I added the observables 'CR(mu->e, Ti)' and 'CR(mu->e, Au)' and their measurements which have already been included in flavio.