### PR TITLE
Custom measurements in likelihoods

### DIFF
--- a/smelli/classes.py
+++ b/smelli/classes.py
@@ -123,11 +123,13 @@ class GlobalLikelihood(object):
           observables and each key is a string that serves as user-defined
           name. For each item of the dictionary, a custom likelihood will be
           computed.
-        - add_measurements: a dictionary in which each key is a likelihood
-          and each value is a list of measurements to be added to that
+        - add_measurements: a dictionary in which each key is a string that
+          corresponds to one of smelli's likelihoods and each value is a list
+          of strings corresponding to the measurements to be added to that
           likelihood.
-        - remove_measurements: a dictionary in which each key is a likelihood
-          and each value is a list of measurements to be removed from that
+        - remove_measurements: a dictionary in which each key is a string that
+          corresponds to one of smelli's likelihoods and each value is a list
+          of strings corresponding to the measurements to be removed from that
           likelihood.
         - fix_ckm: If False (default), automatically determine the CKM elements
           in the presence of new physics in processes used to determine these
@@ -213,13 +215,15 @@ class GlobalLikelihood(object):
                 continue
             with open(self._get_yaml_path(fn), 'r') as f:
                 yaml_dict = flavio.io.yaml.load_include(f)
+                if not self.fix_ckm:
+                    yaml_dict['par_obj'] = par_ckm_dict
                 if fn in add_measurements.keys():
                     yaml_dict['include_measurements'] += add_measurements[fn]
                 if fn in remove_measurements.keys():
                     meas_missing = set(remove_measurements[fn])-set(yaml_dict['include_measurements'])
                     if meas_missing:
                         to_upgrade = 'smelli' if _flavio_up_to_date else 'flavio'
-                        raise AssertionError('The measurements {} have not been found. Please upgrade {} to the latest version.'.format(meas_missing,to_upgrade))
+                        raise ValueErro(f'The measurements {meas_missing} are not part of {fn} and therefore cannot be removed.')
                     for rm in remove_measurements[fn]:
                         yaml_dict['include_measurements'].remove(rm)
                 try:
@@ -252,7 +256,7 @@ class GlobalLikelihood(object):
                     meas_missing = set(remove_measurements[fn])-set(yaml_dict['include_measurements'])
                     if meas_missing:
                         to_upgrade = 'smelli' if _flavio_up_to_date else 'flavio'
-                        raise AssertionError('The measurements {} have not been found. Please upgrade {} to the latest version.'.format(meas_missing,to_upgrade))
+                        raise ValueErro(f'The measurements {meas_missing} are not part of {fn} and therefore cannot be removed.')
                     for rm in remove_measurements[fn]:
                         yaml_dict['include_measurements'].remove(rm)
                 try:

--- a/smelli/classes.py
+++ b/smelli/classes.py
@@ -218,12 +218,14 @@ class GlobalLikelihood(object):
                 if not self.fix_ckm:
                     yaml_dict['par_obj'] = par_ckm_dict
                 if fn in add_measurements.keys():
+                    meas_missing = set(add_measurements[fn]) - set(flavio.Measurement.instances.keys())
+                    if meas_missing:
+                        raise ValueError(f'The measurements {meas_missing} have not been found. Please add them to flavio.')
                     yaml_dict['include_measurements'] += add_measurements[fn]
                 if fn in remove_measurements.keys():
                     meas_missing = set(remove_measurements[fn])-set(yaml_dict['include_measurements'])
                     if meas_missing:
-                        to_upgrade = 'smelli' if _flavio_up_to_date else 'flavio'
-                        raise ValueErro(f'The measurements {meas_missing} are not part of {fn} and therefore cannot be removed.')
+                        raise ValueError(f'The measurements {meas_missing} are not part of {fn} and therefore cannot be removed.')
                     for rm in remove_measurements[fn]:
                         yaml_dict['include_measurements'].remove(rm)
                 try:
@@ -251,12 +253,14 @@ class GlobalLikelihood(object):
             with open(self._get_yaml_path(fn), 'r') as f:
                 yaml_dict = flavio.io.yaml.load_include(f)
                 if fn in add_measurements.keys():
+                    meas_missing = set(add_measurements[fn])-set(flavio.Measurement.instances.keys())
+                    if meas_missing:
+                        raise ValueError(f'The measurements {meas_missing} have not been found. Please add them to flavio.')
                     yaml_dict['include_measurements'] += add_measurements[fn]
                 if fn in remove_measurements.keys():
                     meas_missing = set(remove_measurements[fn])-set(yaml_dict['include_measurements'])
                     if meas_missing:
-                        to_upgrade = 'smelli' if _flavio_up_to_date else 'flavio'
-                        raise ValueErro(f'The measurements {meas_missing} are not part of {fn} and therefore cannot be removed.')
+                        raise ValueError(f'The measurements {meas_missing} are not part of {fn} and therefore cannot be removed.')
                     for rm in remove_measurements[fn]:
                         yaml_dict['include_measurements'].remove(rm)
                 try:

--- a/smelli/test_classes.py
+++ b/smelli/test_classes.py
@@ -55,7 +55,12 @@ class TestGlobalLikelihood(unittest.TestCase):
         self.assertNotIn('likelihood_lfv.yaml', set(ll.keys()))
         self.assertRaises(ValueError, GlobalLikelihood, include_likelihoods=["nonexistent_likelihood.yaml"])
         self.assertRaises(ValueError, GlobalLikelihood, exclude_likelihoods=["nonexistent_likelihood.yaml"])
-        self.assertRaises(ValueError, GlobalLikelihood, custom_measurements={"nonexistent_likelihood.yaml":""})
+        self.assertRaises(ValueError, GlobalLikelihood, add_measurements={"nonexistent_likelihood.yaml":""})
+        self.assertRaises(ValueError, GlobalLikelihood, remove_measurements={"nonexistent_likelihood.yaml":""})
+        self.assertRaises(AssertionError, GlobalLikelihood, add_measurements={"likelihood_ewpt.yaml":"nonexistent_measurement"})
+        self.assertRaises(AssertionError, GlobalLikelihood, remove_measurements={"likelihood_ewpt.yaml":"nonexistent_measurement"})
+
+
 
     def test_chi2_min(self):
         gl_ewpt = GlobalLikelihood(fix_ckm=True, include_likelihoods=[

--- a/smelli/test_classes.py
+++ b/smelli/test_classes.py
@@ -57,8 +57,8 @@ class TestGlobalLikelihood(unittest.TestCase):
         self.assertRaises(ValueError, GlobalLikelihood, exclude_likelihoods=["nonexistent_likelihood.yaml"])
         self.assertRaises(ValueError, GlobalLikelihood, add_measurements={"nonexistent_likelihood.yaml":""})
         self.assertRaises(ValueError, GlobalLikelihood, remove_measurements={"nonexistent_likelihood.yaml":""})
-        self.assertRaises(AssertionError, GlobalLikelihood, add_measurements={"likelihood_ewpt.yaml":"nonexistent_measurement"})
-        self.assertRaises(AssertionError, GlobalLikelihood, remove_measurements={"likelihood_ewpt.yaml":"nonexistent_measurement"})
+        self.assertRaises(ValueError, GlobalLikelihood, add_measurements={"likelihood_ewpt.yaml":"nonexistent_measurement"})
+        self.assertRaises(ValueError, GlobalLikelihood, remove_measurements={"likelihood_ewpt.yaml":"nonexistent_measurement"})
 
 
 

--- a/smelli/test_classes.py
+++ b/smelli/test_classes.py
@@ -55,6 +55,7 @@ class TestGlobalLikelihood(unittest.TestCase):
         self.assertNotIn('likelihood_lfv.yaml', set(ll.keys()))
         self.assertRaises(ValueError, GlobalLikelihood, include_likelihoods=["nonexistent_likelihood.yaml"])
         self.assertRaises(ValueError, GlobalLikelihood, exclude_likelihoods=["nonexistent_likelihood.yaml"])
+        self.assertRaises(ValueError, GlobalLikelihood, custom_measurements={"nonexistent_likelihood.yaml":""})
 
     def test_chi2_min(self):
         gl_ewpt = GlobalLikelihood(fix_ckm=True, include_likelihoods=[


### PR DESCRIPTION
## Rationale
Back in the version 1.x of `flavio` and `smelli`, I used to use `flavio.measurements.read_file()` in conjuction with `smelli.GlobalLikelihood()` for two different situations:

1. Update my fits with new experimental results before the `flavio` database was updated.
2. Simulate the effects of hypothetical/future measurements in the fits.

However, since the introduction of #31, the measurements included in smelli's likelihoods are hard-coded. For use case 1, this is only a minor inconvenience, as the files in the `data/yaml` folder can be manually edited to include new measurements in a permanent way. For use case 2, it would be necessary to edit (and revert the changes) to the yaml files multiple times during runtime. While this is possible, I think it is a somewhat dangerous practice.

So, I propose to restore the previous functionality while still being compliant with #13. My proposal is to add `custom_measurements` as a new optional argument to the constructor of `GlobalLikelihood`.

## How does it work?
The new argument expects a dictionay. The keys of the dictionary are `smelli` likelihoods, as in `GlobalLikelihood.likelihoods.keys()`. The values are lists containing `flavio` measurement identifiers, as in `flavio.Measurement.instances`.

For example, if we define the following new measurements in the file `measurements2027.yaml`
```YAML
LHCb RK 2027:
  experiment: LHCb
  inspire: Noname:2027zzz 
  values: 
     - name: <Rmue>(B+->Kll)
     - q2min: 1.1
     - q2max: 6.0
     - value: 0.8547 +0.0015 -0.0017

LHCb RK* 2027:
  experiment: LHCb
  inspire: Noname:2027yyy 
  values: 
     - name: <Rmue>(B0->K*ll)
     - q2min: 1.1
     - q2max: 6.0
     - value: 0.8732 +0.0018 -0.0021

BelleII RD 2027:
  experiment: Belle II
  inspire: Noname:2027aaa
  values:
    Rtaul(B->Dlnu): 0.3053±0.0037±0.0016
    Rtaul(B->D*lnu): 0.2841±0.0018±0.0014
```
We can import the two first measurements and use them in `smelli` using the following code:
```python
import smelli

smelli.flavio.measurements.read_file('measurements2027.yaml')
gl = smelli.GlobalLikelihood(include_likelihoods=('likelihood_lfu_fcnc.yaml',),
                             custom_measurements={'likelihood_lfu_fcnc.yaml':('LHCb RK 2027', 'LHCb RK* 2027')})
```

Internally, all the new code does is to add the list of measurements introduced by the user to those already read from the yaml file. The code checks that the likelihoods in the keys and the measurements in the values are valid, and raises the corresponding errors in case they aren't.