### PR TITLE
Avoid redundant runnings of the RGEs

### DIFF
--- a/smelli/data/yaml/likelihood_bcpv.yaml
+++ b/smelli/data/yaml/likelihood_bcpv.yaml
@@ -3,3 +3,4 @@ observables: !include_merge_list
   - observables_bkstarmumu_lhcb_a.yaml
 include_measurements: !include_merge_list
   - measurements_bcpv.yaml
+renormalization_scale: 4.8

--- a/smelli/data/yaml/likelihood_bqnunu.yaml
+++ b/smelli/data/yaml/likelihood_bqnunu.yaml
@@ -3,3 +3,4 @@ observables: !include_merge_list
   - observables_bqnunu.yaml
 include_measurements: !include_merge_list
   - measurements_bqnunu.yaml
+renormalization_scale: 4.8

--- a/smelli/data/yaml/likelihood_eeww.yaml
+++ b/smelli/data/yaml/likelihood_eeww.yaml
@@ -2,3 +2,4 @@ observables: !include_merge_list
   - observables_eeww.yaml
 include_measurements: !include_merge_list
   - measurements_eeww.yaml
+renormalization_scale: 91.1876

--- a/smelli/data/yaml/likelihood_ewpt.yaml
+++ b/smelli/data/yaml/likelihood_ewpt.yaml
@@ -2,3 +2,4 @@ observables: !include_merge_list
   - observables_ewpt.yaml
 include_measurements: !include_merge_list
   - measurements_ewpt.yaml
+renormalization_scale: 91.1876

--- a/smelli/data/yaml/likelihood_higgs.yaml
+++ b/smelli/data/yaml/likelihood_higgs.yaml
@@ -2,3 +2,4 @@ observables: !include_merge_list
   - observables_higgs.yaml
 include_measurements: !include_merge_list
   - measurements_higgs.yaml
+renormalization_scale: 125.0

--- a/smelli/data/yaml/likelihood_lfu_fccc.yaml
+++ b/smelli/data/yaml/likelihood_lfu_fccc.yaml
@@ -8,3 +8,4 @@ observables: !include_merge_list
   - observables_klfu.yaml
 include_measurements: !include_merge_list
   - measurements_lfu_fccc.yaml
+renormalization_scale: 4.8

--- a/smelli/data/yaml/likelihood_lfu_fcnc.yaml
+++ b/smelli/data/yaml/likelihood_lfu_fcnc.yaml
@@ -7,3 +7,4 @@ observables: !include_merge_list
   - observables_bqtautau.yaml
 include_measurements: !include_merge_list
   - measurements_lfu_fcnc.yaml
+renormalization_scale: 4.8

--- a/smelli/data/yaml/likelihood_rd_rds.yaml
+++ b/smelli/data/yaml/likelihood_rd_rds.yaml
@@ -5,3 +5,4 @@ observables: !include_merge_list
   - observables_rds.yaml
 include_measurements: !include_merge_list
   - measurements_rd_rds.yaml
+renormalization_scale: 4.8

--- a/smelli/data/yaml/likelihood_zlfv.yaml
+++ b/smelli/data/yaml/likelihood_zlfv.yaml
@@ -3,3 +3,4 @@ observables: !include_merge_list
   - observables_zlfv.yaml
 include_measurements: !include_merge_list
   - measurements_zlfv.yaml
+renormalization_scale: 91.1876


### PR DESCRIPTION
Optimisation of the running of the RG equations, to avoid redundant calculations, as per #53

Needs also the changes in [commit c0fb3b2](https://github.com/Jorge-Alda/flavio/commit/c0fb3b25a951efb608568fb17bea6e9091f6fdcd) in `flavio`.