### PR TITLE
Adds 2023 LHCb measurements of RD and RD*

### DIFF
--- a/smelli/data/yaml/measurements_rd_rds.yaml
+++ b/smelli/data/yaml/measurements_rd_rds.yaml
@@ -5,4 +5,5 @@
 - Belle RD* sl 2019
 - Belle Rmue(B->D*lnu) 2017
 - LHCb RD* 2015
-- LHCb RD* 2017
+- LHCb RD* 2023
+- LHCb RD RD* 2022


### PR DESCRIPTION
Adds the new LHCb measurements, as added to flavio in https://github.com/flav-io/flavio/pull/221