### PR TITLE
Convert GlobalLikelihoodPoint obstable dataframe to "float" type

### DIFF
--- a/smelli/classes.py
+++ b/smelli/classes.py
@@ -1030,7 +1030,7 @@ class GlobalLikelihoodPoint(object):
             del(df['exp. PDF'])
             del(df['ll_central'])
             del(df['ll_sm'])
-        return df
+        return df.astype(float)
 
     @staticmethod
     def _obstable_filter_sort(info, sortkey='name', ascending=True,


### PR DESCRIPTION
The returned obstable is a pandas dataframe with only numerical values, but still has `object` dtype as the internal `_obstable_tree` has numbers and strings.
However, with the `object` dtype, the displaying of the dataframe in jupyter notebooks is bad, e.g. small numbers just get displayed as 0, see this example:
<img width="1252" height="1287" alt="image" src="https://github.com/user-attachments/assets/992ad570-f073-4ec8-a317-9bd2f93d5da7" />

This change just converts to a `float` datatype before returning